### PR TITLE
add repo link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "keywords": [
     "nextcloud"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/icewind1991/notify_push-client.git"
+  },
   "scripts": {
     "build": "tsc",
     "build:doc": "typedoc --out dist/doc lib && touch dist/doc/.nojekyll",


### PR DESCRIPTION
I wasn't so easy to find this repo. Providing the repo url in the `package.json` shows people the link on the [npm page](https://www.npmjs.com/package/@nextcloud/notify_push) :)

